### PR TITLE
Use API_URL env in web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Install dependencies and run the web app:
 ```bash
 cd apps/web
 npm install
+echo "VITE_API_URL=http://localhost:3001" > .env
 npm run dev
 ```
 

--- a/apps/web/.env
+++ b/apps/web/.env
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:3001

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,10 +1,19 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
 
 function App() {
   const [count, setCount] = useState(0)
+  const [users, setUsers] = useState([])
+  const API_URL = import.meta.env.VITE_API_URL
+
+  useEffect(() => {
+    fetch(`${API_URL}/users`)
+      .then((r) => r.json())
+      .then(setUsers)
+      .catch((e) => console.error(e))
+  }, [API_URL])
 
   return (
     <>
@@ -17,6 +26,9 @@ function App() {
         </a>
       </div>
       <h1>Vite + React</h1>
+      <p>
+        <a href={`${API_URL}/zoom/auth`}>Connect Zoom</a>
+      </p>
       <div className="card">
         <button onClick={() => setCount((count) => count + 1)}>
           count is {count}
@@ -25,6 +37,11 @@ function App() {
           Edit <code>src/App.jsx</code> and save to test HMR
         </p>
       </div>
+      <ul>
+        {users.map((u) => (
+          <li key={u.id}>{u.name || u.id}</li>
+        ))}
+      </ul>
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>


### PR DESCRIPTION
## Summary
- define `VITE_API_URL` in `apps/web/.env`
- read API url from `import.meta.env` in the React app
- fetch `/users` from the API and use the url for Zoom auth link
- mention creation of `.env` when running the web frontend

## Testing
- `npm run lint` in `apps/web`

------
https://chatgpt.com/codex/tasks/task_e_6874dfc9eaf0833381c6b0d6d3656b50