### PR TITLE
Add PostgreSQL support to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,28 @@ libs/
 
 ## Getting started
 
-Install dependencies for the API and start the server:
+Install dependencies for the API and start the server. The API now requires a PostgreSQL database.
+
+### Database setup
+
+Create a PostgreSQL database and user. Then copy `.env.example` and adjust the connection variables:
+
+```bash
+cd apps/api
+cp .env.example .env
+```
+The `.env` file should define variables like:
+
+```
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=<user>
+DB_PASSWORD=<password>
+DB_NAME=<database>
+PORT=3001
+```
+
+Ensure a PostgreSQL instance is running and the credentials in `.env` are correct. After that install dependencies and start the server:
 
 ```bash
 cd apps/api
@@ -30,4 +51,4 @@ npm install
 npm run dev
 ```
 
-The API exposes basic endpoints to store users, meetings and transcripts. These are temporary in-memory stores meant as a starting point for development.
+The API exposes CRUD endpoints backed by PostgreSQL to store users, meetings and transcripts.

--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -1,0 +1,6 @@
+DB_HOST=localhost
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=postgres
+DB_NAME=meet
+PORT=3001

--- a/apps/api/db.js
+++ b/apps/api/db.js
@@ -1,0 +1,28 @@
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  user: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+});
+
+module.exports = pool;
+
+async function init() {
+  await pool.query(`CREATE TABLE IF NOT EXISTS users (
+    id SERIAL PRIMARY KEY,
+    data JSONB NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE IF NOT EXISTS meetings (
+    id SERIAL PRIMARY KEY,
+    data JSONB NOT NULL
+  )`);
+  await pool.query(`CREATE TABLE IF NOT EXISTS transcripts (
+    id SERIAL PRIMARY KEY,
+    data JSONB NOT NULL
+  )`);
+}
+
+module.exports.init = init;

--- a/apps/api/index.js
+++ b/apps/api/index.js
@@ -2,45 +2,109 @@ const express = require('express');
 const cors = require('cors');
 const bodyParser = require('body-parser');
 
+const db = require('./db');
+
 const app = express();
 app.use(cors());
 app.use(bodyParser.json());
 
-let users = [];
-let meetings = [];
-let transcripts = [];
+async function start() {
+  await db.init();
 
-app.post('/users', (req, res) => {
-  const user = { id: users.length + 1, ...req.body };
-  users.push(user);
-  res.status(201).json(user);
-});
+  // Users
+  app.post('/users', async (req, res) => {
+    const { rows } = await db.query('INSERT INTO users (data) VALUES ($1) RETURNING id, data', [req.body]);
+    res.status(201).json({ id: rows[0].id, ...rows[0].data });
+  });
 
-app.get('/users', (req, res) => {
-  res.json(users);
-});
+  app.get('/users', async (req, res) => {
+    const { rows } = await db.query('SELECT id, data FROM users');
+    res.json(rows.map(r => ({ id: r.id, ...r.data })));
+  });
 
-app.post('/meetings', (req, res) => {
-  const meeting = { id: meetings.length + 1, ...req.body };
-  meetings.push(meeting);
-  res.status(201).json(meeting);
-});
+  app.get('/users/:id', async (req, res) => {
+    const { rows } = await db.query('SELECT id, data FROM users WHERE id=$1', [req.params.id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json({ id: rows[0].id, ...rows[0].data });
+  });
 
-app.get('/meetings', (req, res) => {
-  res.json(meetings);
-});
+  app.put('/users/:id', async (req, res) => {
+    const { rows } = await db.query('UPDATE users SET data=$1 WHERE id=$2 RETURNING id, data', [req.body, req.params.id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json({ id: rows[0].id, ...rows[0].data });
+  });
 
-app.post('/transcripts', (req, res) => {
-  const transcript = { id: transcripts.length + 1, ...req.body };
-  transcripts.push(transcript);
-  res.status(201).json(transcript);
-});
+  app.delete('/users/:id', async (req, res) => {
+    const { rowCount } = await db.query('DELETE FROM users WHERE id=$1', [req.params.id]);
+    if (rowCount === 0) return res.sendStatus(404);
+    res.sendStatus(204);
+  });
 
-app.get('/transcripts', (req, res) => {
-  res.json(transcripts);
-});
+  // Meetings
+  app.post('/meetings', async (req, res) => {
+    const { rows } = await db.query('INSERT INTO meetings (data) VALUES ($1) RETURNING id, data', [req.body]);
+    res.status(201).json({ id: rows[0].id, ...rows[0].data });
+  });
 
-const PORT = process.env.PORT || 3001;
-app.listen(PORT, () => {
-  console.log(`API server listening on port ${PORT}`);
+  app.get('/meetings', async (req, res) => {
+    const { rows } = await db.query('SELECT id, data FROM meetings');
+    res.json(rows.map(r => ({ id: r.id, ...r.data })));
+  });
+
+  app.get('/meetings/:id', async (req, res) => {
+    const { rows } = await db.query('SELECT id, data FROM meetings WHERE id=$1', [req.params.id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json({ id: rows[0].id, ...rows[0].data });
+  });
+
+  app.put('/meetings/:id', async (req, res) => {
+    const { rows } = await db.query('UPDATE meetings SET data=$1 WHERE id=$2 RETURNING id, data', [req.body, req.params.id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json({ id: rows[0].id, ...rows[0].data });
+  });
+
+  app.delete('/meetings/:id', async (req, res) => {
+    const { rowCount } = await db.query('DELETE FROM meetings WHERE id=$1', [req.params.id]);
+    if (rowCount === 0) return res.sendStatus(404);
+    res.sendStatus(204);
+  });
+
+  // Transcripts
+  app.post('/transcripts', async (req, res) => {
+    const { rows } = await db.query('INSERT INTO transcripts (data) VALUES ($1) RETURNING id, data', [req.body]);
+    res.status(201).json({ id: rows[0].id, ...rows[0].data });
+  });
+
+  app.get('/transcripts', async (req, res) => {
+    const { rows } = await db.query('SELECT id, data FROM transcripts');
+    res.json(rows.map(r => ({ id: r.id, ...r.data })));
+  });
+
+  app.get('/transcripts/:id', async (req, res) => {
+    const { rows } = await db.query('SELECT id, data FROM transcripts WHERE id=$1', [req.params.id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json({ id: rows[0].id, ...rows[0].data });
+  });
+
+  app.put('/transcripts/:id', async (req, res) => {
+    const { rows } = await db.query('UPDATE transcripts SET data=$1 WHERE id=$2 RETURNING id, data', [req.body, req.params.id]);
+    if (rows.length === 0) return res.sendStatus(404);
+    res.json({ id: rows[0].id, ...rows[0].data });
+  });
+
+  app.delete('/transcripts/:id', async (req, res) => {
+    const { rowCount } = await db.query('DELETE FROM transcripts WHERE id=$1', [req.params.id]);
+    if (rowCount === 0) return res.sendStatus(404);
+    res.sendStatus(204);
+  });
+
+  const PORT = process.env.PORT || 3001;
+  app.listen(PORT, () => {
+    console.log(`API server listening on port ${PORT}`);
+  });
+}
+
+start().catch(err => {
+  console.error('Failed to start server', err);
+  process.exit(1);
 });

--- a/apps/api/package-lock.json
+++ b/apps/api/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "body-parser": "^2.2.0",
         "cors": "^2.8.5",
-        "express": "^5.1.0"
+        "express": "^5.1.0",
+        "pg": "^8.16.3"
       }
     },
     "node_modules/accepts": {
@@ -580,6 +581,134 @@
         "node": ">=16"
       }
     },
+    "node_modules/pg": {
+      "version": "8.16.3",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
+      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-connection-string": "^2.9.1",
+        "pg-pool": "^3.10.1",
+        "pg-protocol": "^1.10.3",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
+      },
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "optionalDependencies": {
+        "pg-cloudflare": "^1.2.7"
+      },
+      "peerDependencies": {
+        "pg-native": ">=3.0.1"
+      },
+      "peerDependenciesMeta": {
+        "pg-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pg-cloudflare": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
+      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/pg-connection-string": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
+      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "license": "MIT"
+    },
+    "node_modules/pg-int8": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
+      "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/pg-pool": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
+      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "pg": ">=8.0"
+      }
+    },
+    "node_modules/pg-protocol": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
+      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "license": "MIT"
+    },
+    "node_modules/pg-types": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
+      "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "license": "MIT",
+      "dependencies": {
+        "pg-int8": "1.0.1",
+        "postgres-array": "~2.0.0",
+        "postgres-bytea": "~1.0.0",
+        "postgres-date": "~1.0.4",
+        "postgres-interval": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/pgpass": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
+      "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.1.0"
+      }
+    },
+    "node_modules/postgres-array": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
+      "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postgres-bytea": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
+      "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-date": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
+      "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/postgres-interval": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
+      "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -789,6 +918,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -844,6 +982,15 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4"
+      }
     }
   }
 }

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
   "dependencies": {
     "body-parser": "^2.2.0",
     "cors": "^2.8.5",
-    "express": "^5.1.0"
+    "express": "^5.1.0",
+    "pg": "^8.16.3"
   }
 }


### PR DESCRIPTION
## Summary
- connect API to PostgreSQL using `pg`
- create tables and connection helper
- implement CRUD endpoints using the database
- provide `.env.example` and document DB setup

## Testing
- `npm test` *(fails: Missing script)*
- `node index.js` *(fails: ECONNREFUSED since PostgreSQL isn't running)*

------
https://chatgpt.com/codex/tasks/task_e_6874dfcbbcbc8333a59d0d9ed033f264